### PR TITLE
Chrome blocks image loading because of CORS security

### DIFF
--- a/pk2/PKwithGS/bullet.js
+++ b/pk2/PKwithGS/bullet.js
@@ -1,11 +1,11 @@
 class Bullet{
 
-  constructor(location, bulletType, angle){
+  constructor(location, bImg, angle){
+    // issue#1 use preloaded bullet image instead of loadImage
     this.loc = location;
-    this.bullTyp = bulletType
     this.speed = 12;
     this.angle = angle;
-    this.img = this.loadImage();
+    this.img = bImg;
   }
 
   loadImage(){

--- a/pk2/PKwithGS/game.js
+++ b/pk2/PKwithGS/game.js
@@ -24,11 +24,30 @@ class Game {
     this.cnv.mouseMoved(handleCNVMouseMoved);
     this.cnv.mouseOver(handleCNVMouseOver);
     this.cnv.mouseClicked(handleCNVMouseClicked);
+
+    // issue#1  preload images with createImg()
+    // the small turret images
+    this.tow1sImg = createImg("tow1s.png",this.hideImgElement);
+    this.tow2sImg = createImg("tow2s.png",this.hideImgElement);
+    this.tow3sImg = createImg("tow3s.png",this.hideImgElement);
+    this.tow4sImg = createImg("tow4s.png",this.hideImgElement);
+    this.tow5sImg = createImg("tow5s.png",this.hideImgElement);
+    // the bullet images
+    this.b1Img = createImg("b1.png",this.hideImgElement);
+    this.b2Img = createImg("b2.png",this.hideImgElement);
+    this.b3Img = createImg("b3.png",this.hideImgElement);
+    this.b4Img = createImg("b4.png",this.hideImgElement);
+    this.b5Img = createImg("b5.png",this.hideImgElement);
+
+
+
   }
+
+  hideImgElement() { this.hide(); }
 
   run() { // called from draw()
     clear();
-    println('bullets.length = ' + this.bullets.length);
+    // println('bullets.length = ' + this.bullets.length);
     let gt = this.updateGameTime();
     this.updateInfoElements(gt);
     this.removeBullets();
@@ -108,32 +127,42 @@ class Game {
   }
 
   createTower(tn) {
-    //create a new tower object and add to array list
+    // create a new tower object and add to array list
+    // issue#1 use preloaded turret and bullet images
+    // and eliminate Tower (turret) subclasses.
+    var loc = createVector(width / 2, height / 2);
+    var cost = 100;
+    var tImg, bImg;
     switch(tn) {
       case 1:
-      var tower = new TowerOne(createVector(width / 2, height / 2), 100, "b1");
-      this.towers.push(tower); // add tower to the end of the array of towers
-      break;
+        tImg = this.tow1sImg;
+        bImg = this.b1Img;
+        break;
       case 2:
-      var tower = new TowerTwo(createVector(width / 2, height / 2), 100, "b2");
-      this.towers.push(tower); // add tower to the end of the array of towers
-      break;
+        tImg = this.tow2sImg;
+        bImg = this.b2Img;
+        break;
       case 3:
-      var tower = new TowerThree(createVector(width / 2, height / 2), 100, "b3");
-      this.towers.push(tower); // add tower to the end of the array of towers
-      break;
+        tImg = this.tow3sImg;
+        bImg = this.b3Img;
+        break;
       case 4:
-      var tower = new TowerFour(createVector(width / 2, height / 2), 100, "b4");
-      this.towers.push(tower); // add tower to the end of the array of towers
-      break;
+        tImg = this.tow4sImg;
+        bImg = this.b4Img;
+        break;
       case 5:
-      var tower = new TowerFive(createVector(width / 2, height / 2), 100, "b5");
-      this.towers.push(tower); // add tower to the end of the array of towers
-      break;
+        tImg = this.tow5sImg;
+        bImg = this.b5Img;
+        break;
       default:
       println('failed to make turret');
     }
-
+    var tower = new Tower(loc, cost, tImg, bImg);
+    if(tower)
+      this.towers.push(tower); // add tower to the end of the array of towers
+    else {
+      println('failed to make turret');
+    }
   }
 
   placeTower() {

--- a/pk2/PKwithGS/tower.js
+++ b/pk2/PKwithGS/tower.js
@@ -1,11 +1,12 @@
 class Tower {
-  constructor(loc, cost, bullet) {
+  // issue#1 use preloaded images
+  constructor(loc, cost, tImg, bImg) {
     this.loc = loc;
     this.placed = false;
     this.visible = false;
     this.cost = cost;
-    this.bullet = bullet;
-    this.towerNum = 0;
+    this.bulletImg = bImg;
+    this.towImg = tImg;
     this.towAngle = 0;
     this.lastTime = millis();
     this.coolDown = 500;
@@ -40,55 +41,9 @@ class Tower {
           // reset lastTime to current time
           this.lastTime = millis();
           let bulletLocation = createVector(this.loc.x, this.loc.y);
-          let b = new Bullet(bulletLocation ,  this.bullet, this.towAngle);
+          let b = new Bullet(bulletLocation , this.bulletImg, this.towAngle);
           towerGame.bullets.push(b);
     }
   }
 
 }//  end Tower class +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-class TowerOne extends Tower {
-  constructor(loc, cost, bullet) {
-    super(loc, cost, bullet);
-    this.towerNum = 1;
-    this.towImg = loadImage('tow1s.png');
-  }
-
-}//  end Tower_One class
-
-class TowerTwo extends Tower {
-  constructor(loc, cost, bullet) {
-    super(loc, cost, bullet);
-    this.towerNum = 2;
-    this.towImg = loadImage('tow2s.png');
-  }
-
-}//  end Tower_Two class
-
-class TowerThree extends Tower {
-  constructor(loc, cost, bullet) {
-    super(loc, cost, bullet);
-    this.towerNum = 3;
-    this.towImg = loadImage('tow3s.png');
-  }
-
-}//  end Tower_three class
-
-class TowerFour extends Tower {
-  constructor(loc, cost, bullet) {
-    super(loc, cost, bullet);
-    this.towerNum = 4;
-    this.towImg = loadImage('tow4s.png');
-  }
-
-}//  end Tower_three class
-
-class TowerFive extends Tower {
-  constructor(loc, cost, bullet) {
-    super(loc, cost, bullet);
-    this.towerNum = 5;
-    this.towImg = loadImage('tow5s.png');
-
-  }
-
-}//  end Tower_three class


### PR DESCRIPTION
According to Shiffman in
https://github.com/processing/p5.js/issues/561, one should be able to
call createImg() in p5 and then image() to draw it on the canvas.  If
so, that could work around Chrome blocking access to the image because
of cross-origin security.

It does work to use createImg() which returns a p5.Element instead of
loadImage() which returns a p5.Image.  Why I don’t know but now we can
preload images for all the small turrets and bullets and we do not have
any cross-origin security blocks when running without a server.