### PR TITLE
tower.js and bullet.js missing 'use strict'

### DIFF
--- a/pk2/PKwithGS/bullet.js
+++ b/pk2/PKwithGS/bullet.js
@@ -1,3 +1,5 @@
+'use strict'
+
 class Bullet{
 
   constructor(location, bImg, angle){

--- a/pk2/PKwithGS/tower.js
+++ b/pk2/PKwithGS/tower.js
@@ -1,3 +1,5 @@
+'use strict'
+
 class Tower {
   // issue#1 use preloaded images
   constructor( cost, tImg, bImg) {


### PR DESCRIPTION
The p5 app threw errors because of the missing ‘use strict’ directives